### PR TITLE
[HELM] Fix missing yaml conversion for expander priorities

### DIFF
--- a/charts/cluster-autoscaler/templates/priority-expander-configmap.yaml
+++ b/charts/cluster-autoscaler/templates/priority-expander-configmap.yaml
@@ -12,6 +12,6 @@ metadata:
   {{- end }}
 data:
   priorities: |-
-{{ .Values.expanderPriorities | indent 4 }}
+{{ toYaml .Values.expanderPriorities | indent 4 }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This might fix an error I'm seeing with Helm when passing expanderPriorities:

```
Error: template: cluster-autoscaler/templates/priority-expander-configmap.yaml:11:39: executing "cluster-autoscaler/templates/priority-expander-configmap.yaml" at <4>: wrong type for value; expected string; got map[string]interface {}
```